### PR TITLE
Fixed Gruntfile regex for replace:dist.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,7 +133,7 @@ module.exports = function (grunt) {
 				src: ['<%= phantom.dist %>/default.hbs'],
 				overwrite: true,
 				replacements: [{
-					from: /<link rel="stylesheet" type="text\/css" href="\/assets\/css\/normalize.css" \/>\n/g,
+                    from: /\s*<link rel="stylesheet" type="text\/css" href="{{asset "\/css\/normalize.css"}}" \/>/,
 					to: function(matchedWord, index, fullText, regexMatches) {
 						return '';
 					}


### PR DESCRIPTION
I noticed my blog was getting a 404 on normalize.css.  I wasn't sure if normalize.css was supposed to be compiled into main.css or left as a discrete file until I found the replace:dist config in the Gruntfile.
