### PR TITLE
Fix link to config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Edit [partials/sidebar.hbs](https://github.com/Bartinger/phantom/blob/master/par
 - Minimalistic responsive
 - Google Analytics
 - Disqus comments
-- Icon-font ([Fontello](/assets/fonts/config.json))
+- Icon-font ([Fontello](/assets/font/config.json))
 - Post images*
 
 * I've added them to the post.hbs template to make them discoverable by social sites if someone posts the link to this blog post. Though they are hidden in the template because I wanted to keep it clean. You can enable and style them by editing ```_posts.scss``` or ```standalone/assets/css/main.css``` for standalone users.


### PR DESCRIPTION
The link to `config.json` is broken since the folder `fonts` does not exist. This PR addresses the issue.